### PR TITLE
docs: variable name, not value of variable

Update template-syntax.md

The same is the variable name rather than the value of variable. (#272)

### DIFF
--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -68,7 +68,7 @@ Vue تستخدم صيغة القالب المستند على الـHTML التي
 
 - Only supported in 3.4+
 
-If the attribute has the same name with the JavaScript value being bound, the syntax can be further shortened to omit the attribute value:
+If the attribute has the same name as the variable name of the JavaScript value being bound, the syntax can be further shortened to omit the attribute value:
 
 ```vue-html
 <!-- same as :id="id" -->


### PR DESCRIPTION
resolves #272
Cherry picked from https://github.com/vuejs/docs/commit/854be522a9c75ecad05ded8e0fd22c94e32237ce