### PR TITLE
chore(deps): bump @vue/repl from 4.5.1 to 4.6.1

Bumps [@vue/repl](https://github.com/vuejs/repl) from 4.5.1 to 4.6.1.
- [Release notes](https://github.com/vuejs/repl/releases)
- [Changelog](https://github.com/vuejs/repl/blob/main/CHANGELOG.md)
- [Commits](https://github.com/vuejs/repl/compare/v4.5.1...v4.6.1)

---
updated-dependencies:
- dependency-name: "@vue/repl"
  dependency-version: 4.6.1
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com> (#294)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@vue/repl':
         specifier: ^4.4.2
-        version: 4.5.1
+        version: 4.6.1
       '@vue/theme':
         specifier: ^2.3.0
         version: 2.3.0(@algolia/client-search@5.20.0)(search-insights@2.17.2)(vitepress@1.6.3(@algolia/client-search@5.20.0)(@types/node@22.7.5)(postcss@8.5.1)(search-insights@2.17.2)(typescript@5.6.3))(vue@3.5.13(typescript@5.6.3))
@@ -601,8 +601,8 @@ packages:
   '@vue/reactivity@3.5.13':
     resolution: {integrity: sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==}
 
-  '@vue/repl@4.5.1':
-    resolution: {integrity: sha512-YYXvFue2GOrZ6EWnoA8yQVKzdCIn45+tpwJHzMof1uwrgyYAVY9ynxCsDYeAuWcpaAeylg/nybhFuqiFy2uvYA==}
+  '@vue/repl@4.6.1':
+    resolution: {integrity: sha512-tgeEa+QXzqbFsAIbq/dCXzOJxIW2Nq1F79KXRjbKyPt1ODpCx86bDbFgNzFcBEK3In2/mjPTMpN7fSD6Ig0Qsw==}
 
   '@vue/runtime-core@3.5.13':
     resolution: {integrity: sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==}
@@ -1595,7 +1595,7 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.13
 
-  '@vue/repl@4.5.1': {}
+  '@vue/repl@4.6.1': {}
 
   '@vue/runtime-core@3.5.13':
     dependencies:

--- a/src/ecosystem/themes/themes.json
+++ b/src/ecosystem/themes/themes.json
@@ -337,7 +337,7 @@
         "name": "Sneat - Vue Laravel Admin",
         "price": 0,
         "description": "Free & Open Source VueJS Laravel Admin using Sneat Design System",
-        "url": "https://themeselection.com/item/sneat-free-vuetify-vuejs-laravel-admin-template/ref=14",
+        "url": "https://themeselection.com/item/sneat-free-vuetify-vuejs-laravel-admin-template/?ref=14",
         "image": "https://cdn.themeselection.com/ts-assets/sneat/sneat-vuetify-vuejs-laravel-admin-template-free/banner/banner.png"
       },
       {


### PR DESCRIPTION
resolves #294
Cherry picked from https://github.com/vuejs/docs/commit/7648af482716e9f6bb9a856135231e58a95a3ae8